### PR TITLE
add truncate so that certain plugins don't break

### DIFF
--- a/db.php
+++ b/db.php
@@ -529,7 +529,7 @@ class m_wpdb extends wpdb {
 		//Remove carriage returns https://stackoverflow.com/questions/3059091/how-to-remove-carriage-returns-from-output-of-string
 		$query=trim(preg_replace('~[[:cntrl:]]~', ' ', $query));
 
-		if ( preg_match( "/^\\s*(insert|delete|update|replace|alter|create|drop) /i", $query ) ) {
+		if ( preg_match( "/^\\s*(insert|delete|update|replace|alter|create|drop|truncate) /i", $query ) ) {
 			$this->rows_affected = mysqli_affected_rows( $dbh );
 			// Take note of the insert_id
 			if ( preg_match( "/^\\s*(insert|replace) /i", $query ) ) {


### PR DESCRIPTION
This has been an issue with Facet WP and H5P. It may also impact other plugins but this addition fixes the issue. It is in use on our large multisite without issue thus far. 